### PR TITLE
Always specify the Content-Type header

### DIFF
--- a/Controller/FileController.php
+++ b/Controller/FileController.php
@@ -68,11 +68,13 @@ class FileController extends Controller
 
         $disposition = 'attachment';
         $adapter = $fs->getAdapter();
-        if ($adapter instanceof Local && !$download) {
+        if ($adapter instanceof Local) {
             $mimeType = $adapter->mimeType($filename);
             if ($mimeType) {
                 $response->headers->set('Content-Type', $mimeType);
-                $disposition = 'inline';
+                if (!$download) {
+                    $disposition = 'inline';
+                }
             }
         }
         $response->headers->set(


### PR DESCRIPTION
Fixes the Safari bug where when the content type is missing, it adds .html extension, preventing users to open the file.