### PR TITLE
don't throw exception when we upload other than a FlysystemFile class

### DIFF
--- a/EventListener/ResourceUploader.php
+++ b/EventListener/ResourceUploader.php
@@ -39,8 +39,7 @@ class ResourceUploader
     {
         $file = $event->getFile();
         if (!$file instanceof FlysystemFile) {
-            $class = get_class($file);
-            throw new \UnexpectedValueException("Only Flysystem Files are supported, '{$class}' given");
+            return;
         }
 
         $originalFilename = $file->getBasename();


### PR DESCRIPTION
When we tried to override SidusUploadBundle and OnupUploaderBundle in order to upload new types of files we are blocked with the ResourceSubscriber and the ResourceManager class.

So I replaced the exception by a simple return. This allow to create new listeners for differents upload types.